### PR TITLE
resource_search API optionally returns private resources

### DIFF
--- a/ckan/logic/action/get.py
+++ b/ckan/logic/action/get.py
@@ -2026,12 +2026,17 @@ def resource_search(context, data_dict):
     :type offset: int
     :param limit: Apply a limit to the query.
     :type limit: int
+    :param include_private: if ``True``, resources from private datasets will
+        be included in the results. Only resources from private datasets in
+        the user's organizations will be returned and sysadmins will be
+        returned all private resources. Optional, the default is ``False``.
 
     :returns:  A dictionary with a ``count`` field, and a ``results`` field.
     :rtype: dict
 
     '''
     model = context['model']
+    user = context.get('user')
 
     # Allow either the `query` or `fields` parameter to be given, but not both.
     # Once `fields` parameter is dropped, this can be made simpler.
@@ -2070,6 +2075,19 @@ def resource_search(context, data_dict):
             split_terms[field] = terms
         fields = split_terms
 
+    include_private = asbool(data_dict.get('include_private', False))
+
+    # return a version of `q` which limits access to private datasets,
+    # appropriate to the access level of the current user
+    def _protect_private(q):
+        if include_private and authz.is_sysadmin(user):
+            return q
+        if include_private and user:
+            orgs = logic.get_action('organization_list_for_user')(
+                {'user': user}, {'permission': 'read'})
+            return q.filter(model.Package.owner_org.in_([org['id'] for org in orgs]))
+        return q.filter(model.Package.private == False)
+
     order_by = data_dict.get('order_by')
     offset = data_dict.get('offset')
     limit = data_dict.get('limit')
@@ -2077,8 +2095,8 @@ def resource_search(context, data_dict):
     q = model.Session.query(model.Resource) \
          .join(model.Package) \
          .filter(model.Package.state == 'active') \
-         .filter(model.Package.private == False) \
-         .filter(model.Resource.state == 'active') \
+         .filter(model.Resource.state == 'active')
+    q = _protect_private(q)
 
     resource_fields = model.Resource.get_columns()
     for field, terms in fields.items():

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -610,7 +610,8 @@ def default_resource_search_schema():
         'fields': [ignore_missing],  # dict of fields
         'order_by': [ignore_missing, unicode],
         'offset': [ignore_missing, natural_number_validator],
-        'limit': [ignore_missing, natural_number_validator]
+        'limit': [ignore_missing, natural_number_validator],
+        'include_private': [ignore_missing, boolean_validator],
     }
     return schema
 


### PR DESCRIPTION
Add a new `include_private` flag to the resource_search endpoint

If set, return resources attached to private packages to which the
authenticated user has access.