### PR TITLE
user login redirect to home page

### DIFF
--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -165,7 +165,7 @@ class UserController(base.BaseController):
             h.redirect_to(locale=locale, controller='user', action='login',
                           id=None)
         user_ref = c.userobj.get_reference_preferred_for_uri()
-        # login redirect to homepage
+        # login redirect to homepage bpa-archive-ops/issues#770
         h.redirect_to('/')
 
     def check_permissions(self):

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -159,6 +159,13 @@ class UserController(base.BaseController):
                 context, {'id': c.user_dict['id']})
 
         return render('user/read.html')
+    
+    def me(self, locale=None):
+        if not c.user:
+            h.redirect_to(locale=locale, controller='user', action='login',
+                          id=None)
+        user_ref = c.userobj.get_reference_preferred_for_uri()
+        h.redirect_to('/')
 
     def check_permissions(self):
         if not c.user:
@@ -614,13 +621,6 @@ class UserController(base.BaseController):
                               action='login', came_from=came_from)
             else:
                 return self.login(error=err)
-
-    def me(self, locale=None):
-        if not c.user:
-            h.redirect_to(locale=locale, controller='user', action='login',
-                          id=None)
-        user_ref = c.userobj.get_reference_preferred_for_uri()
-        h.redirect_to('/')
 
     def logout(self):
         # Do any plugin logout stuff

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -160,13 +160,6 @@ class UserController(base.BaseController):
 
         return render('user/read.html')
 
-    def me(self, locale=None):
-        if not c.user:
-            h.redirect_to(locale=locale, controller='user', action='login',
-                          id=None)
-        user_ref = c.userobj.get_reference_preferred_for_uri()
-        h.redirect_to(locale=locale, controller='user', action='dashboard')
-
     def check_permissions(self):
         if not c.user:
             abort(403, 'Please log into CKAN.')
@@ -621,6 +614,13 @@ class UserController(base.BaseController):
                               action='login', came_from=came_from)
             else:
                 return self.login(error=err)
+
+    def me(self, locale=None):
+        if not c.user:
+            h.redirect_to(locale=locale, controller='user', action='login',
+                          id=None)
+        user_ref = c.userobj.get_reference_preferred_for_uri()
+        h.redirect_to('/')
 
     def logout(self):
         # Do any plugin logout stuff

--- a/ckan/controllers/user.py
+++ b/ckan/controllers/user.py
@@ -159,12 +159,13 @@ class UserController(base.BaseController):
                 context, {'id': c.user_dict['id']})
 
         return render('user/read.html')
-    
+
     def me(self, locale=None):
         if not c.user:
             h.redirect_to(locale=locale, controller='user', action='login',
                           id=None)
         user_ref = c.userobj.get_reference_preferred_for_uri()
+        # login redirect to homepage
         h.redirect_to('/')
 
     def check_permissions(self):


### PR DESCRIPTION
Fixes #
changed user logged_in redirect to homepage 

### Proposed fixes:

The main reason for the modifications are to help provide an easier navigation to users who may not be familiar with the site.
Could we have the “dataset view” page (https://data.bioplatforms.com/) as the first page visible after login instead of the one below (https://data.bioplatforms.com/dashboard) ? For a first-time user, it is not obvious where to navigate to from the start.

### Features:

- [x] redirect to homepage instead of user dashboard after user login issue - https://github.com/BioplatformsAustralia/bpa-archive-ops/issues/770 

Please [X] all the boxes above that apply
